### PR TITLE
Ws 2.4.2 add foreign key for species id from sightings

### DIFF
--- a/backend/Migrations/20240909133821_AddRelationOneToManySpeciesSightings.Designer.cs
+++ b/backend/Migrations/20240909133821_AddRelationOneToManySpeciesSightings.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using WhaleSpotting;
@@ -11,9 +12,11 @@ using WhaleSpotting;
 namespace WhaleSpotting.Migrations
 {
     [DbContext(typeof(WhaleSpottingContext))]
-    partial class WhaleSpottingContextModelSnapshot : ModelSnapshot
+    [Migration("20240909133821_AddRelationOneToManySpeciesSightings")]
+    partial class AddRelationOneToManySpeciesSightings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Migrations/20240909133821_AddRelationOneToManySpeciesSightings.cs
+++ b/backend/Migrations/20240909133821_AddRelationOneToManySpeciesSightings.cs
@@ -1,0 +1,49 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WhaleSpotting.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRelationOneToManySpeciesSightings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "WhaleSpeciesId",
+                table: "Sightings",
+                newName: "SpeciesId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sightings_SpeciesId",
+                table: "Sightings",
+                column: "SpeciesId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Sightings_Species_SpeciesId",
+                table: "Sightings",
+                column: "SpeciesId",
+                principalTable: "Species",
+                principalColumn: "SpeciesId",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Sightings_Species_SpeciesId",
+                table: "Sightings");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Sightings_SpeciesId",
+                table: "Sightings");
+
+            migrationBuilder.RenameColumn(
+                name: "SpeciesId",
+                table: "Sightings",
+                newName: "WhaleSpeciesId");
+        }
+    }
+}

--- a/backend/Models/Data/Sighting.cs
+++ b/backend/Models/Data/Sighting.cs
@@ -10,7 +10,10 @@ public class Sighting
     [Key]
     public int Id { get; set; }
     public int UserId { get; set; }
-    public int WhaleSpeciesId { get; set; }
+
+    public int SpeciesId { get; set; }
+    public Species Species {get; set;}
+    
     public float Latitude { get; set; }
     public float Longitude { get; set; }
     public string PhotoUrl { get; set; }

--- a/backend/Models/Data/Species.cs
+++ b/backend/Models/Data/Species.cs
@@ -8,5 +8,6 @@ public class Species
     public string TailPictureLink { get; set; } = string.Empty;
     public string WikiLink { get; set; } = string.Empty;
     public int TotalSightings { get; set; } = 0;
-
+    
+    public ICollection<Sighting> Sightings { get; } = new List<Sighting>();
 }

--- a/backend/Models/Request/SightingsRequest.cs
+++ b/backend/Models/Request/SightingsRequest.cs
@@ -5,7 +5,7 @@ namespace WhaleSpotting.Models.Request;
 public class SightingsRequest
 {
     public int UserId { get; set; }
-    public int WhaleSpeciesId { get; set; }
+    public int SpeciesId { get; set; }
     public float Latitude { get; set; }
     public float Longitude { get; set; }
     public string PhotoUrl { get; set; }

--- a/backend/Services/SightingsService.cs
+++ b/backend/Services/SightingsService.cs
@@ -23,7 +23,7 @@ public class SightingsService : ISightingsService
         Sighting sighting = new Sighting()
         {
             UserId = sightingsRequest.UserId,
-            WhaleSpeciesId = sightingsRequest.WhaleSpeciesId,
+            SpeciesId = sightingsRequest.SpeciesId,
             Latitude = sightingsRequest.Latitude,
             Longitude = sightingsRequest.Longitude,
             PhotoUrl = sightingsRequest.PhotoUrl,

--- a/backend/WhaleSpottingContext.cs
+++ b/backend/WhaleSpottingContext.cs
@@ -33,6 +33,12 @@ public class WhaleSpottingContext(DbContextOptions<WhaleSpottingContext> options
         builder.Entity<Species>(builder =>
         {
             builder.HasIndex(sp => sp.SpeciesName);
+            builder.HasMany(e => e.Sightings)
+            .WithOne(e => e.Species)
+            .HasForeignKey(e => e.SpeciesId)
+            .IsRequired();
         });
+
     }
+
 }

--- a/backend/WhaleSpottingContext.cs
+++ b/backend/WhaleSpottingContext.cs
@@ -29,10 +29,10 @@ public class WhaleSpottingContext(DbContextOptions<WhaleSpottingContext> options
         };
         builder.Entity<Role>().HasData(userRole, adminRole);
 
-        // Indexing SpeciesName
         builder.Entity<Species>(builder =>
         {
             builder.HasIndex(sp => sp.SpeciesName);
+            
             builder.HasMany(e => e.Sightings)
             .WithOne(e => e.Species)
             .HasForeignKey(e => e.SpeciesId)


### PR DESCRIPTION
1. update the Sightings.cs file to have a foreign key for [Species.Id](http://species.id/) 
2. renaming "WhaleSpeciesId” property to “SpeciesId” in files with it, to match Species table - and also because we have also other cetaceans in our species
3. update the Species.cs file to be the parent of Sightings.cs SpeciesId property
4. Amend WhalesSpottingContext to implement one-to-many relationship
5. Add new migration AddRelationOneToManySpeciesSightings
