### PR TITLE
Ws  allows admin to approve sightings

### DIFF
--- a/backend/Controllers/AdminController.cs
+++ b/backend/Controllers/AdminController.cs
@@ -1,8 +1,5 @@
-using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using WhaleSpotting.Models.Data;
-using WhaleSpotting.Models.Request;
-using WhaleSpotting.Models.Response;
 using WhaleSpotting.Services;
 
 namespace WhaleSpotting.Controllers;
@@ -13,6 +10,17 @@ public class AdminController(ISightingsService sightingsService) : Controller
 {
     private readonly ISightingsService _sightingsService = sightingsService;
 
-    // [HttpPut("approve/sighting={sightingId}")]
-    // public async Task<IActionResult> Update(UpdateSightingsRequest sightingRequest, [FromRoute] int sightingId, int userId) {}
+    [HttpPut("approve/sighting={sightingId}"), Authorize("Roles=Admin")]
+    public async Task<IActionResult> ApproveSighting([FromRoute] int sightingId)
+    {
+        try
+        {
+            await _sightingsService.ApproveSighting(sightingId);
+            return Ok();
+        }
+        catch (Exception e)
+        {
+            return BadRequest(e.Message);
+        }
+    }
 }

--- a/backend/Controllers/AdminController.cs
+++ b/backend/Controllers/AdminController.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using WhaleSpotting.Models.Data;
+using WhaleSpotting.Models.Request;
+using WhaleSpotting.Models.Response;
+using WhaleSpotting.Services;
+
+namespace WhaleSpotting.Controllers;
+
+[ApiController]
+[Route("/admin")]
+public class AdminController(ISightingsService sightingsService) : Controller
+{
+    private readonly ISightingsService _sightingsService = sightingsService;
+
+    // [HttpPut("approve/sighting={sightingId}")]
+    // public async Task<IActionResult> Update(UpdateSightingsRequest sightingRequest, [FromRoute] int sightingId, int userId) {}
+}

--- a/backend/Controllers/AdminController.cs
+++ b/backend/Controllers/AdminController.cs
@@ -5,12 +5,13 @@ using WhaleSpotting.Services;
 namespace WhaleSpotting.Controllers;
 
 [ApiController]
+[Authorize(Roles="Admin")]
 [Route("/admin")]
 public class AdminController(ISightingsService sightingsService) : Controller
 {
     private readonly ISightingsService _sightingsService = sightingsService;
 
-    [HttpPut("approve/sighting={sightingId}"), Authorize(Roles="Admin")]
+    [HttpPut("approve/sighting={sightingId}")]
     public async Task<IActionResult> ApproveSighting([FromRoute] int sightingId)
     {
         try

--- a/backend/Controllers/AdminController.cs
+++ b/backend/Controllers/AdminController.cs
@@ -10,7 +10,7 @@ public class AdminController(ISightingsService sightingsService) : Controller
 {
     private readonly ISightingsService _sightingsService = sightingsService;
 
-    [HttpPut("approve/sighting={sightingId}"), Authorize("Roles=Admin")]
+    [HttpPut("approve/sighting={sightingId}"), Authorize(Roles="Admin")]
     public async Task<IActionResult> ApproveSighting([FromRoute] int sightingId)
     {
         try

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -37,7 +37,7 @@ public class Program
             options.UseNpgsql(builder.Configuration.GetConnectionString("Postgres"));
         });
 
-        builder.Services.AddIdentity<User, Role>().AddEntityFrameworkStores<WhaleSpottingContext>();
+        builder.Services.AddIdentity<User, Role>().AddEntityFrameworkStores<WhaleSpottingContext>();  
 
         builder.Services.AddTransient<SeedSpecies>();
         builder.Services.AddTransient<IUserService, UserService>();

--- a/backend/Services/SightingsService.cs
+++ b/backend/Services/SightingsService.cs
@@ -9,6 +9,7 @@ public interface ISightingsService
     public Task CreateSighting(SightingsRequest sightingsRequest);
     public Task<Sighting> GetSightingById(int sightingId);
     public Task DeleteSighting(int sightingId, int userId);
+    public Task ApproveSighting(int sightingId);
 }
 
 public class SightingsService : ISightingsService
@@ -68,6 +69,24 @@ public class SightingsService : ISightingsService
         catch
         {
             throw new InvalidOperationException($"Sighting with ID {sightingId} cannot be deleted");
+        }
+    }
+
+    public async Task ApproveSighting(int sightingId)
+    {
+
+        Sighting sighting = await GetSightingById(sightingId);
+
+        sighting.IsApproved = true;
+
+        try
+        {
+            _context.Sightings.Update(sighting);
+            _context.SaveChanges();
+        }
+        catch
+        {
+            throw new InvalidOperationException($"Sighting with ID {sightingId} cannot be approved");
         }
     }
 }


### PR DESCRIPTION
- Create a new controller AdminController with route “admin”
- Create a new endpoint in AdminController to approve sightings with [HttpPut(“approve/sighting={sightingId}")]
- Use [Authorize(”Roles=Admin”)] to make sure the endpoint can be accessed by admins only
- Add a new method to SightingsService for changing IsApproved from false to true and update the database