### PR TITLE
Ws 10.1 change all endpoints to get user id from claims

### DIFF
--- a/backend/Controllers/SightingsController.cs
+++ b/backend/Controllers/SightingsController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
@@ -25,8 +26,13 @@ public class SightingsController : Controller
     {
         try
         {
-            await _sightingService.CreateSighting(sightingRequest);
+            int userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
+            await _sightingService.CreateSighting(sightingRequest, userId);
             return Ok();
+        }
+        catch(NullReferenceException ex)
+        {
+            return BadRequest($"User identifier not found. {ex.Message}");
         }
         catch (Exception ex)
         {
@@ -48,13 +54,18 @@ public class SightingsController : Controller
         }
     }
 
-    [HttpDelete("{sightingId}/delete&user={userId}")]
-    public async Task<IActionResult> Delete([FromRoute] int sightingId, int userId)
+    [HttpDelete("{sightingId}/delete")]
+    public async Task<IActionResult> Delete([FromRoute] int sightingId)
     {
         try
         {
+            int userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
             await _sightingService.DeleteSighting(sightingId, userId);
             return Ok();
+        }
+        catch (NullReferenceException ex)
+        {
+            return BadRequest($"User identifier not found. {ex.Message}");
         }
         catch (UnauthorizedAccessException ex)
         {
@@ -66,13 +77,18 @@ public class SightingsController : Controller
         }
     }
 
-    [HttpPut("{sightingId}/update&user={userId}")]
-    public async Task<IActionResult> Update(UpdateSightingsRequest sightingRequest, [FromRoute] int sightingId, int userId)
+    [HttpPut("{sightingId}/update")]
+    public async Task<IActionResult> Update(SightingsRequest sightingRequest, [FromRoute] int sightingId)
     {
         try
         {
+            int userId = int.Parse(User.FindFirst(ClaimTypes.NameIdentifier).Value);
             await _sightingService.UpdateSighting(sightingRequest, sightingId, userId);
             return Ok();
+        }
+        catch(NullReferenceException ex)
+        {
+            return BadRequest($"User identifier not found. {ex.Message}");
         }
         catch (UnauthorizedAccessException ex)
         {

--- a/backend/Controllers/UserController.cs
+++ b/backend/Controllers/UserController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
@@ -26,74 +27,100 @@ public class UserController(IUserService userService) : Controller
         return Ok(new UserResponse { Id = matchingUser.Id, UserName = matchingUser.UserName, });
     }
 
-    [HttpPost("/{userId}/update")]
-    public async Task<IActionResult> UpdateUser([FromRoute] string userId, UpdateUserRequest userRequest)
+    [HttpPost("/update")]
+    public async Task<IActionResult> UpdateUser(UpdateUserRequest userRequest)
     {
-        User? user = _userService.FindById(userId).Result;
-        var errorResponse = new ErrorResponse();
-        var generalErrors = new List<string>();
-
-        if (user == null)
+        try
         {
-            return NotFound();
-        }
-
-        if (user.IsSuspended)
-        {
-            errorResponse.Errors["User is suspended"] = generalErrors;
-            return BadRequest(errorResponse);
-        }
-
-        if (userRequest.FirstName != null)
-        {
-            user.FirstName = userRequest.FirstName;
-        }
-        if (userRequest.LastName != null)
-        {
-            user.LastName = userRequest.LastName;
-        }
-        if (userRequest.AboutMe != null)
-        {
-            user.AboutMe = userRequest.AboutMe;
-        }
-
-        await _userService.Update(user);
-
-        return Ok(
-            new UpdateUserResponse
-            {
-                Id = user.Id,
-                FirstName = user.FirstName,
-                LastName = user.LastName,
-                AboutMe = user.AboutMe
-            }
-        );
-    }
-
-    [HttpDelete("{userId}")]
-    public async Task<IActionResult> Delete([FromRoute] string userId)
-    {
-        User? user = _userService.FindById(userId).Result;
-
-        if (user == null)
-        {
-            return NotFound();
-        }
-
-        IdentityResult result = _userService.Delete(user).Result;
-
-        if (!result.Succeeded)
-        {
+            string userId = User.FindFirst(ClaimTypes.NameIdentifier).Value;
+            User? user = _userService.FindById(userId).Result;
             var errorResponse = new ErrorResponse();
             var generalErrors = new List<string>();
-            foreach (var error in result.Errors)
+
+            if (user == null)
             {
-                generalErrors.Add(error.Description);
+                return NotFound();
             }
-            errorResponse.Errors["General"] = generalErrors;
-            return BadRequest(errorResponse);
+
+            if (user.IsSuspended)
+            {
+                errorResponse.Errors["User is suspended"] = generalErrors;
+                return BadRequest(errorResponse);
+            }
+
+            if (userRequest.FirstName != null)
+            {
+                user.FirstName = userRequest.FirstName;
+            }
+            if (userRequest.LastName != null)
+            {
+                user.LastName = userRequest.LastName;
+            }
+            if (userRequest.AboutMe != null)
+            {
+                user.AboutMe = userRequest.AboutMe;
+            }
+
+            await _userService.Update(user);
+
+            return Ok(
+                new UpdateUserResponse
+                {
+                    Id = user.Id,
+                    FirstName = user.FirstName,
+                    LastName = user.LastName,
+                    AboutMe = user.AboutMe
+                }
+            );
+        }
+        catch (NullReferenceException ex)
+        {
+            return BadRequest($"User identifier not found. {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(ex.Message);
         }
 
-        return Ok();
     }
+
+    [HttpDelete("")]
+    public async Task<IActionResult> Delete()
+    {
+        try
+        {
+            string userId = User.FindFirst(ClaimTypes.NameIdentifier).Value;
+            User? user = _userService.FindById(userId).Result;
+
+            if (user == null)
+            {
+                return NotFound();
+            }
+
+            IdentityResult result = _userService.Delete(user).Result;
+
+            if (!result.Succeeded)
+            {
+                var errorResponse = new ErrorResponse();
+                var generalErrors = new List<string>();
+                foreach (var error in result.Errors)
+                {
+                    generalErrors.Add(error.Description);
+                }
+                errorResponse.Errors["General"] = generalErrors;
+                return BadRequest(errorResponse);
+            }
+
+            return Ok();
+        }
+        catch (NullReferenceException ex)
+        {
+            return BadRequest($"User identifier not found. {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+
 }

--- a/backend/Models/Request/SightingsRequest.cs
+++ b/backend/Models/Request/SightingsRequest.cs
@@ -2,17 +2,6 @@ namespace WhaleSpotting.Models.Request;
 
 public class SightingsRequest
 {
-    public int UserId { get; set; }
-    public int SpeciesId { get; set; }
-    public float Latitude { get; set; }
-    public float Longitude { get; set; }
-    public string PhotoUrl { get; set; }
-    public string? Description { get; set; }
-    public DateTime DateTime { get; set; }
-} 
-
-public class UpdateSightingsRequest
-{
     public int SpeciesId { get; set; }
     public float Latitude { get; set; }
     public float Longitude { get; set; }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -45,11 +45,9 @@ public class Program
 
         builder.Services.AddTransient<SeedSpecies>();
         builder.Services.AddTransient<IUserService, UserService>();
-<<<<<<< WS2.8-add-sighting-seed-data
         builder.Services.AddTransient<SeedSightings>();
-=======
         builder.Services.AddTransient<ISpeciesService, SpeciesService>();
->>>>>>> main
+
 
         builder
             .Services.AddAuthentication(options =>

--- a/backend/Services/SightingsService.cs
+++ b/backend/Services/SightingsService.cs
@@ -7,11 +7,11 @@ namespace WhaleSpotting.Services;
 
 public interface ISightingsService
 {
-    public Task CreateSighting(SightingsRequest sightingsRequest);
+    public Task CreateSighting(SightingsRequest sightingsRequest, int userId);
     public SightingListResponse GetApproved();
     public Task<Sighting> GetSightingById(int sightingId);
     public Task DeleteSighting(int sightingId, int userId);
-    public Task UpdateSighting(UpdateSightingsRequest sightingsRequest, int sightingId, int userId);
+    public Task UpdateSighting(SightingsRequest sightingsRequest, int sightingId, int userId);
 }
 
 public class SightingsService : ISightingsService
@@ -23,11 +23,11 @@ public class SightingsService : ISightingsService
         _context = context;
     }
 
-    public async Task CreateSighting(SightingsRequest sightingsRequest)
+    public async Task CreateSighting(SightingsRequest sightingsRequest, int userId)
     {
         Sighting sighting = new Sighting()
         {
-            UserId = sightingsRequest.UserId,
+            UserId = userId,
             SpeciesId = sightingsRequest.SpeciesId,
             Latitude = sightingsRequest.Latitude,
             Longitude = sightingsRequest.Longitude,
@@ -84,7 +84,7 @@ public class SightingsService : ISightingsService
         }
     }
 
-    public async Task UpdateSighting(UpdateSightingsRequest sightingsRequest, int sightingId, int userId)
+    public async Task UpdateSighting(SightingsRequest sightingsRequest, int sightingId, int userId)
     {
 
         Sighting sighting = await GetSightingById(sightingId);


### PR DESCRIPTION
- updated Sightings Controller adding “userId = User.FindFirst(ClaimTypes.NameIdentifier).Value)” to all endpoints that required it

- In order to add the above code into the “sightings/create” endpoint, we had to update the SightingsRequest.cs and SightingsService.cs > “CreateSighting” method so that he userId comes from the backend and frontend does not need to provide it

- SightingsRequest and UpdateSightingRequest were now identical, so we merged them into only one SightingsRequest

- updated UserController to add “userId = User.FindFirst(ClaimTypes.NameIdentifier).Value)” and the relative try/catch error handling lines of code

- successfully tested with Swagger and Postman

