### PR TITLE
Ws 5.6 approve sightings

### DIFF
--- a/backend/Controllers/SightingsController.cs
+++ b/backend/Controllers/SightingsController.cs
@@ -54,6 +54,21 @@ public class SightingsController : Controller
         }
     }
 
+    [Authorize(Roles = "Admin")]
+    [HttpGet("unapproved")]
+    public ActionResult<SightingListResponse> GetUnapproved()
+    {
+        try
+        {
+            SightingListResponse sightings = _sightingService.GetUnapproved();
+            return Ok(sightings);
+        }
+        catch (Exception ex)
+        {
+            return BadRequest(ex.Message);
+        }
+    }
+
     [HttpDelete("{sightingId}/delete")]
     public async Task<IActionResult> Delete([FromRoute] int sightingId)
     {

--- a/backend/Models/Response/SightingListResponse.cs
+++ b/backend/Models/Response/SightingListResponse.cs
@@ -15,6 +15,7 @@ public class SightingListResponse()
         {
             SightingResponse sightingResponse = new SightingResponse()
             {
+                Id = sighting.Id,
                 UserId = sighting.UserId,
                 SpeciesId = sighting.SpeciesId,
                 Latitude = sighting.Latitude,

--- a/backend/Models/Response/SightingResponse.cs
+++ b/backend/Models/Response/SightingResponse.cs
@@ -2,6 +2,7 @@ namespace WhaleSpotting.Models.Response;
 
 public class SightingResponse
 {
+    public int Id { get; set; }
     public int UserId { get; set; }
     public int SpeciesId { get; set; }
     public float Latitude { get; set; }

--- a/backend/Services/SightingsService.cs
+++ b/backend/Services/SightingsService.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
 using WhaleSpotting.Models.Data;
 using WhaleSpotting.Models.Request;
@@ -10,6 +9,7 @@ public interface ISightingsService
 {
     public Task CreateSighting(SightingsRequest sightingsRequest, int userId);
     public SightingListResponse GetApproved();
+    public SightingListResponse GetUnapproved();
     public Task<Sighting> GetSightingById(int sightingId);
     public Task DeleteSighting(int sightingId, int userId);
     public Task UpdateSighting(SightingsRequest sightingsRequest, int sightingId, int userId);
@@ -48,6 +48,14 @@ public class SightingsService : ISightingsService
     public SightingListResponse GetApproved()
     {
         List<Sighting> sightings = _context.Sightings.Where(s => s.IsApproved).ToList();
+        SightingListResponse sightingListResponse = new SightingListResponse();
+        sightingListResponse.SetList(sightings);
+        return sightingListResponse;
+    }
+
+    public SightingListResponse GetUnapproved()
+    {
+        List<Sighting> sightings = _context.Sightings.Where(s => !s.IsApproved).ToList();
         SightingListResponse sightingListResponse = new SightingListResponse();
         sightingListResponse.SetList(sightings);
         return sightingListResponse;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "bootstrap": "^5.3.3",
+        "moment": "^2.30.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-scripts": "^5.0.1",
@@ -12438,6 +12439,14 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,6 @@
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "bootstrap": "^5.3.3",
-    "moment": "^2.30.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "^5.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "bootstrap": "^5.3.3",
+    "moment": "^2.30.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "^5.0.1",

--- a/frontend/src/api/backendClient.ts
+++ b/frontend/src/api/backendClient.ts
@@ -12,6 +12,7 @@ export interface Sightings {
 }
 
 export interface Sighting {
+  id: number
   userId: number
   speciesId: number
   latitude: number

--- a/frontend/src/api/backendClient.ts
+++ b/frontend/src/api/backendClient.ts
@@ -69,6 +69,17 @@ export async function fetchUnapprovedSightings(header: string): Promise<Sighting
   return await response.json()
 }
 
+export async function approveSighting(header: string, sightingId: number) {
+  const response = await fetch(`http://localhost:5280/admin/approve/sighting=${sightingId}`, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${header}`,
+    },
+    method: "PUT",
+  })
+  return await response
+}
+
 // to add the JWT token as a header to fetch requests which access protected endpoints do the following:
 // In the .tsx file where the fetch request is being called:
 // 1) import the login context to access the value of the JWT token

--- a/frontend/src/api/backendClient.ts
+++ b/frontend/src/api/backendClient.ts
@@ -1,3 +1,26 @@
+export interface User {
+  userName: string
+  firstName: string
+  lastName: string
+  email: string
+  totalPointsEarned: number
+  aboutMe: string
+}
+
+export interface Sightings {
+  sightings: Array<Sighting>
+}
+
+export interface Sighting {
+  userId: number
+  speciesId: number
+  latitude: number
+  longitude: number
+  photoUrl: string
+  description: string
+  dateTime: string
+}
+
 export const loginUser = async (username: string, password: string) => {
   return await fetch(`http://localhost:5280/auth/login`, {
     method: "post",
@@ -33,6 +56,16 @@ export const registerUser = async (
       aboutme,
     }),
   })
+}
+
+export async function fetchUnapprovedSightings(header: string): Promise<Sightings> {
+  const response = await fetch(`http://localhost:5280/sightings/unapproved`, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${header}`,
+    },
+  })
+  return await response.json()
 }
 
 // to add the JWT token as a header to fetch requests which access protected endpoints do the following:

--- a/frontend/src/pages/Admin/Admin.scss
+++ b/frontend/src/pages/Admin/Admin.scss
@@ -1,0 +1,19 @@
+@import "~bootstrap/dist/css/bootstrap.min.css";
+@import "./../../colour-variables.scss";
+
+.btn-primary {
+  background-color: $whale-logo-yellow;
+  color: $whale-main-blue;
+  border: $whale-logo-yellow;
+}
+
+.btn-primary:hover {
+  background-color: $whale-light-blue;
+  color: $whale-main-blue;
+  border: $whale-light-blue;
+}
+
+.custom-thumbnail {
+  width: 20vw;
+  max-width: 200px;
+}

--- a/frontend/src/pages/Admin/Admin.tsx
+++ b/frontend/src/pages/Admin/Admin.tsx
@@ -1,10 +1,18 @@
-import { useContext } from "react"
+import { useContext, useEffect, useState } from "react"
 import { LoginContext } from "../../Components/LoginManager/LoginManager"
+import { fetchUnapprovedSightings, Sightings } from "../../api/backendClient"
 
 const Admin = () => {
-  const { roleType } = useContext(LoginContext)
+  const loginContext = useContext(LoginContext)
+  const [sightings, setSightings] = useState<Sightings | null>(null)
 
-  if (roleType === "Admin") {
+  useEffect(() => {
+    fetchUnapprovedSightings(loginContext.jwt).then((response) => setSightings(response))
+  }, [loginContext.jwt])
+
+  console.log(sightings)
+
+  if (loginContext.roleType === "Admin") {
     return (
       <div>
         <h1 data-testid="adminTitle">Admin Page</h1>

--- a/frontend/src/pages/Admin/Admin.tsx
+++ b/frontend/src/pages/Admin/Admin.tsx
@@ -1,6 +1,7 @@
 import { useContext, useEffect, useState } from "react"
 import { LoginContext } from "../../Components/LoginManager/LoginManager"
 import { approveSighting, fetchUnapprovedSightings, Sightings } from "../../api/backendClient"
+import "./Admin.scss"
 
 const Admin = () => {
   const loginContext = useContext(LoginContext)
@@ -19,26 +20,57 @@ const Admin = () => {
     })
   }
 
+  const formatDate = (dateTime: string) => {
+    return new Date(dateTime).toLocaleString("en-GB", { timeZone: "UTC" })
+  }
+
   if (loginContext.roleType === "Admin") {
     return (
-      <div>
-        <h1 data-testid="adminTitle">Admin Page</h1>
-        <table>
-          {sightings?.sightings.map((sighting) => (
-            <tr>
-              <td>{sighting.userId}</td>
-              <td>{sighting.speciesId}</td>
-              <td>{sighting.latitude}</td>
-              <td>{sighting.longitude}</td>
-              <td>{sighting.photoUrl}</td>
-              <td>{sighting.description}</td>
-              <td>{sighting.dateTime}</td>
-              <td>
-                <button onClick={() => handleClick(loginContext.jwt, sighting.id)}>Approve</button>
-              </td>
-            </tr>
-          ))}
-        </table>
+      <div className="px-4">
+        <h1 data-testid="adminTitle" className="py-4">
+          Admin Page
+        </h1>
+        <div className="table-responsive">
+          <table className="table table-striped">
+            <thead>
+              <tr>
+                <th scope="col">Sighting Id</th>
+                <th scope="col">User Id</th>
+                <th scope="col">Species Id</th>
+                <th scope="col">Latitude</th>
+                <th scope="col">Longitude</th>
+                <th scope="col">Photo</th>
+                <th scope="col">Description</th>
+                <th scope="col">Submission Date/Time</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sightings?.sightings.map((sighting) => (
+                <tr>
+                  <th scope="row">{sighting.id}</th>
+                  <td>{sighting.userId}</td>
+                  <td>{sighting.speciesId}</td>
+                  <td>{sighting.latitude}</td>
+                  <td>{sighting.longitude}</td>
+                  <td>
+                    <img className="img-thumbnail custom-thumbnail" alt="A whale" src={sighting.photoUrl} />
+                  </td>
+                  <td>{sighting.description}</td>
+                  <td>{formatDate(sighting.dateTime)}</td>
+                  <td>
+                    <button
+                      className="btn btn-primary btn-md"
+                      onClick={() => handleClick(loginContext.jwt, sighting.id)}
+                    >
+                      Approve
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       </div>
     )
   } else {
@@ -51,7 +83,3 @@ const Admin = () => {
 }
 
 export default Admin
-
-// sightings = [sighting, sighting]
-
-// sightings = {sightings: [sighting1, sighting2]}

--- a/frontend/src/pages/Admin/Admin.tsx
+++ b/frontend/src/pages/Admin/Admin.tsx
@@ -1,16 +1,23 @@
 import { useContext, useEffect, useState } from "react"
 import { LoginContext } from "../../Components/LoginManager/LoginManager"
-import { fetchUnapprovedSightings, Sightings } from "../../api/backendClient"
+import { approveSighting, fetchUnapprovedSightings, Sightings } from "../../api/backendClient"
 
 const Admin = () => {
   const loginContext = useContext(LoginContext)
   const [sightings, setSightings] = useState<Sightings | null>(null)
+  const [approvals, setApprovals] = useState(0)
 
   useEffect(() => {
     fetchUnapprovedSightings(loginContext.jwt).then((response) => setSightings(response))
-  }, [loginContext.jwt])
+  }, [loginContext.jwt, approvals])
 
-  console.log(sightings)
+  const handleClick = (header: string, id: number) => {
+    approveSighting(header, id).then((response) => {
+      if (response.ok) {
+        setApprovals(approvals + 1)
+      }
+    })
+  }
 
   if (loginContext.roleType === "Admin") {
     return (
@@ -27,7 +34,7 @@ const Admin = () => {
               <td>{sighting.description}</td>
               <td>{sighting.dateTime}</td>
               <td>
-                <button>Approve</button>
+                <button onClick={() => handleClick(loginContext.jwt, sighting.id)}>Approve</button>
               </td>
             </tr>
           ))}

--- a/frontend/src/pages/Admin/Admin.tsx
+++ b/frontend/src/pages/Admin/Admin.tsx
@@ -16,6 +16,22 @@ const Admin = () => {
     return (
       <div>
         <h1 data-testid="adminTitle">Admin Page</h1>
+        <table>
+          {sightings?.sightings.map((sighting) => (
+            <tr>
+              <td>{sighting.userId}</td>
+              <td>{sighting.speciesId}</td>
+              <td>{sighting.latitude}</td>
+              <td>{sighting.longitude}</td>
+              <td>{sighting.photoUrl}</td>
+              <td>{sighting.description}</td>
+              <td>{sighting.dateTime}</td>
+              <td>
+                <button>Approve</button>
+              </td>
+            </tr>
+          ))}
+        </table>
       </div>
     )
   } else {
@@ -28,3 +44,7 @@ const Admin = () => {
 }
 
 export default Admin
+
+// sightings = [sighting, sighting]
+
+// sightings = {sightings: [sighting1, sighting2]}


### PR DESCRIPTION
- add new endpoint to sightings controller which gets all unapproved sightings
- add error handling
- add new method to the sightings service to support this
- write new fetch request in backendClient.ts to call this endpoint - import the header from the login context - passed as a prop from the admin page component
- set up a useEffect in Admin page which runs the fetch request on first render of the component
- set up a useState to store the sightings
- write the TSX to display the sightings - iterate through list from useState variable
- Add ‘approve’ button
- Add ‘approve’ fetch request to backendClient.ts
- link the button to an onClick which will trigger a fetch request to the admin controller ‘approve’ endpoint
- trigger a re-render of the page which will display the new list of sightings
- Add styling