### PR TITLE
WS BugFix update button in profile page

### DIFF
--- a/frontend/src/pages/Profile/Profile.tsx
+++ b/frontend/src/pages/Profile/Profile.tsx
@@ -38,19 +38,6 @@ export function Profile(): JSX.Element {
   
   const userData = { firstName: user?.firstName, lastName: user?.lastName, aboutMe: user?.aboutMe }
 
-  const handleClick = (event: { currentTarget: { id: string }}) => {
-    const buttonId = event.currentTarget.id
-    switch (buttonId) {
-      case "update-button":
-        navigate("/updateprofile", { state: userData })
-        break
-      case "delete-button":
-        break
-      default:
-        break
-    }
-  }
-
   if (!user) {
     return <section>You are not authorized to view this page</section>
   }
@@ -117,7 +104,7 @@ export function Profile(): JSX.Element {
           </div>
           <div className="row g-0">
             <div className="col-6 p-2">
-              <button id="update-button" data-testid="update-button" className="btn btn-primary btn-md w-100">
+              <button id="update-button" data-testid="update-button" className="btn btn-primary btn-md w-100" onClick={() => navigate("/updateprofile", { state: userData })}>
                 Update
               </button>
             </div>


### PR DESCRIPTION
Implemented navigate("/updateprofile") on the button itself and removed the switchstatement as there was only two cases and one was not being used.