### PR TITLE
added user name and species name instead of ID in admin screen

### DIFF
--- a/frontend/src/api/backendClient.ts
+++ b/frontend/src/api/backendClient.ts
@@ -23,7 +23,9 @@ export interface Sightings {
 export interface Sighting {
   id: number
   userId: number
+  username: string
   speciesId: number
+  speciesName: string
   latitude: number
   longitude: number
   photoUrl: string
@@ -73,7 +75,7 @@ export const getSightings = async (header: string) => {
     method: "get",
     headers: {
       "Content-Type": "application/json",
-      "Authorization": `Bearer ${header}`
+      Authorization: `Bearer ${header}`,
     },
   })
 }
@@ -94,9 +96,9 @@ export async function FetchLeaderBoard(header: string) {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${header}`,
-      },
-    })
-    if (!response.ok) {
+    },
+  })
+  if (!response.ok) {
     return response.json().then((errorData) => {
       throw new Error(JSON.stringify(errorData.errors))
     })
@@ -104,12 +106,7 @@ export async function FetchLeaderBoard(header: string) {
   return await response.json()
 }
 
-export const updateUser = async (
-  header: string,
-  firstname?: string,
-  lastname?: string,
-  aboutme?: string,
-) => {
+export const updateUser = async (header: string, firstname?: string, lastname?: string, aboutme?: string) => {
   return await fetch(`http://localhost:5280/users/update`, {
     method: "put",
     headers: {
@@ -129,7 +126,7 @@ export async function fetchUnapprovedSightings(header: string): Promise<Sighting
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${header}`,
-      },
+    },
   })
   return await response.json()
 }

--- a/frontend/src/pages/Admin/Admin.tsx
+++ b/frontend/src/pages/Admin/Admin.tsx
@@ -35,8 +35,8 @@ const Admin = () => {
             <thead>
               <tr>
                 <th scope="col">Sighting Id</th>
-                <th scope="col">User Id</th>
-                <th scope="col">Species Id</th>
+                <th scope="col">User Name</th>
+                <th scope="col">Species Name</th>
                 <th scope="col">Latitude</th>
                 <th scope="col">Longitude</th>
                 <th scope="col">Photo</th>
@@ -49,8 +49,8 @@ const Admin = () => {
               {sightings?.sightings.map((sighting) => (
                 <tr>
                   <th scope="row">{sighting.id}</th>
-                  <td>{sighting.userId}</td>
-                  <td>{sighting.speciesId}</td>
+                  <td>{sighting.username}</td>
+                  <td>{sighting.speciesName}</td>
                   <td>{sighting.latitude}</td>
                   <td>{sighting.longitude}</td>
                   <td>


### PR DESCRIPTION
Shows user name and species name instead of user id and species id in admin approve sightings page:

- added username and species name in Sighting interface in the backendClients
- tested this out via the front-end admin screen