### PR TITLE
Adds endpoint to admin controlled to get user by username

### DIFF
--- a/backend/Controllers/AdminController.cs
+++ b/backend/Controllers/AdminController.cs
@@ -29,7 +29,7 @@ public class AdminController(ISightingsService sightingsService, IUserService us
         }
     }
 
-            [HttpGet("user/username={username}")]
+    [HttpGet("user/username={username}")]
     public async Task<IActionResult> FindByName([FromRoute] string username){
         User? matchingUser = _userService.FindByName(username).Result;
         if (matchingUser == null)

--- a/backend/Controllers/AdminController.cs
+++ b/backend/Controllers/AdminController.cs
@@ -1,15 +1,19 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using WhaleSpotting.Services;
+using WhaleSpotting.Models.Data;
+using WhaleSpotting.Models.Response;
+
 
 namespace WhaleSpotting.Controllers;
 
 [ApiController]
 [Authorize(Roles = "Admin")]
 [Route("/admin")]
-public class AdminController(ISightingsService sightingsService) : Controller
+public class AdminController(ISightingsService sightingsService, IUserService userService) : Controller
 {
     private readonly ISightingsService _sightingsService = sightingsService;
+     private readonly IUserService _userService = userService;
 
     [HttpPut("approve/sighting={sightingId}")]
     public async Task<IActionResult> ApproveSighting([FromRoute] int sightingId)
@@ -24,4 +28,15 @@ public class AdminController(ISightingsService sightingsService) : Controller
             return BadRequest(e.Message);
         }
     }
+
+            [HttpGet("user/username={username}")]
+    public async Task<IActionResult> FindByName([FromRoute] string username){
+        User? matchingUser = _userService.FindByName(username).Result;
+        if (matchingUser == null)
+        {
+            return NotFound();
+        }
+        return Ok(new UserResponse { Id = matchingUser.Id, UserName = matchingUser.UserName});
+    }
+
 }


### PR DESCRIPTION
HTTPGet endpoint added to admin controller.
Takes in username and returns either status Ok with UserResponse model or NotFound.
Currently UserResponse only gives username and userId, we might want more information to returned to the admin user?