### PR TITLE
WS allow admin to delete user

### DIFF
--- a/backend/Controllers/AdminController.cs
+++ b/backend/Controllers/AdminController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using WhaleSpotting.Models.Data;
 using WhaleSpotting.Services;
 
 namespace WhaleSpotting.Controllers;
@@ -7,9 +8,10 @@ namespace WhaleSpotting.Controllers;
 [ApiController]
 [Authorize(Roles = "Admin")]
 [Route("/admin")]
-public class AdminController(ISightingsService sightingsService) : Controller
+public class AdminController(ISightingsService sightingsService, IUserService userService) : Controller
 {
     private readonly ISightingsService _sightingsService = sightingsService;
+    private readonly IUserService _userService = userService;
 
     [HttpPut("approve/sighting={sightingId}")]
     public async Task<IActionResult> ApproveSighting([FromRoute] int sightingId)
@@ -18,6 +20,25 @@ public class AdminController(ISightingsService sightingsService) : Controller
         {
             await _sightingsService.ApproveSighting(sightingId);
             return Ok();
+        }
+        catch (Exception e)
+        {
+            return BadRequest(e.Message);
+        }
+    }
+
+    [HttpDelete("users/delete/{username}")]
+    public async Task<IActionResult> DeleteUser([FromRoute] string username)
+    {
+        try
+        {
+            User user = await _userService.FindByName(username);
+            if (user is null) {
+                return BadRequest("User does not exist");
+            }
+
+            await _userService.Delete(user);
+            return NoContent();
         }
         catch (Exception e)
         {

--- a/backend/Controllers/AdminController.cs
+++ b/backend/Controllers/AdminController.cs
@@ -34,7 +34,7 @@ public class AdminController(ISightingsService sightingsService, IUserService us
         {
             User user = await _userService.FindByName(username);
             if (user is null) {
-                return BadRequest("User does not exist");
+                return BadRequest($"User {username} does not exist");
             }
 
             await _userService.Delete(user);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15885,9 +15885,10 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },


### PR DESCRIPTION
Added an IUserService object to AdminController.cs

Added an endpoint to delete a user using a supplied username

Manual unit testing performed:

PgAdmin4 before the user has been deleted:
![PriorToDelete](https://github.com/user-attachments/assets/22853c1e-f95d-4741-9f5f-84e48996a06e)

Result in Swagger when the user has been deleted:
![SwaggerResult](https://github.com/user-attachments/assets/1c85866f-9638-44f6-ae7f-b2d91b3d2bd6)

PgAdmin4 after the user has been deleted:
![AfterDelete](https://github.com/user-attachments/assets/7cd9b17e-3b5c-4c6a-8f95-5825796ab275)

Result in Swagger when an attempt to delete an non-existent user is requested:
![AfterUserHasBeenDeleted](https://github.com/user-attachments/assets/c8d88380-c7c3-48f2-aeff-213afd76d40f)

