### PR TITLE
Fix AddSighting - incorrect responses saved to DB

### DIFF
--- a/frontend/src/pages/AddSighting/AddSighting.tsx
+++ b/frontend/src/pages/AddSighting/AddSighting.tsx
@@ -103,6 +103,7 @@ export function AddSighting(): JSX.Element {
                 type="url"
                 id="photoUrl"
                 className="form-control"
+                required
                 value={photoUrl}
                 onChange={(event) => setPhotoUrl(event.target.value)}
               />

--- a/frontend/src/pages/UpdateSighting/UpdateSighting.tsx
+++ b/frontend/src/pages/UpdateSighting/UpdateSighting.tsx
@@ -108,6 +108,7 @@ export function UpdateSighting(): JSX.Element {
                 type="url"
                 id="photoUrl"
                 className="form-control"
+                required
                 value={photoUrl}
                 onChange={(event) => setPhotoUrl(event.target.value)}
               />


### PR DESCRIPTION
Added "required" to the photoURL input field and that has resolved the “Oh no! Something did not go swimmingly, please try again." message as well as making the photo mandatory